### PR TITLE
Fix readme preview issue

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -7,7 +7,7 @@ Provide an easy way to generate `DeepCopy` function for `data class`. DeepCopy o
 Use Kotlin Reflection to provide an extension function for `DeepCopyable` so that any data class can simply call `deepCopy()` to copy itsself.
 
 See the test code below: 
-~~~~
+
 ```kotlin
 data class Speaker(val name: String, val age: Int): DeepCopyable
 


### PR DESCRIPTION
Hey @bennyhuo.

These _(seemingly?)_ unnecessary characters '~~~~' in the ReadMe.md file are causing issues while rendering the markdown preview. Removing those characters is fixing the issue, and the thing renders fine.

This PR just removes those characters.